### PR TITLE
Add Noodle Biomedical Literature Discovery

### DIFF
--- a/database/github/helena-bioinformatics/noodle-mcp/metadata.json
+++ b/database/github/helena-bioinformatics/noodle-mcp/metadata.json
@@ -1,0 +1,48 @@
+{
+    "parser": "github",
+    "uid": "github/helena-bioinformatics/noodle-mcp",
+    "url": "https://github.com/helena-bioinformatics/noodle-mcp",
+    "data": {
+        "name": "noodle-mcp",
+        "url": "https://github.com/helena-bioinformatics/noodle-mcp",
+        "full_name": "helena-bioinformatics/noodle-mcp",
+        "html_url": "https://github.com/helena-bioinformatics/noodle-mcp",
+        "private": false,
+        "description": "Noodle Biomedical Literature Discovery MCP — search papers and traverse citation or semantic literature graphs.",
+        "created_at": "2026-08-29T20:48:27Z",
+        "updated_at": "2026-08-30T13:09:12Z",
+        "clone_url": "https://github.com/helena-bioinformatics/noodle-mcp.git",
+        "homepage": "https://noodle.helena.bio/integrations",
+        "size": 218,
+        "stargazers_count": 0,
+        "watchers_count": 0,
+        "language": "Python",
+        "open_issues_count": 0,
+        "license": {
+            "key": "apache-2.0",
+            "name": "Apache License 2.0",
+            "spdx_id": "Apache-2.0",
+            "url": "https://api.github.com/licenses/apache-2.0",
+            "node_id": "MDc6TGljZW5zZTI="
+        },
+        "subscribers_count": 0,
+        "owner": {
+            "html_url": "https://github.com/helena-bioinformatics",
+            "avatar_url": "https://avatars.githubusercontent.com/u/243391023?v=4",
+            "login": "helena-bioinformatics",
+            "type": "Organization"
+        },
+        "topics": [
+            "agent-skill",
+            "bioinformatics",
+            "biomedical-literature",
+            "citation-graph",
+            "mcp-server",
+            "model-context-protocol",
+            "pubmed",
+            "semantic-search"
+        ],
+        "timestamp": "2026-08-31 12:28:54.113329",
+        "avatar": "https://avatars.githubusercontent.com/u/243391023?v=4"
+    }
+}


### PR DESCRIPTION
Adds Noodle Biomedical Literature Discovery to the static Research Software Encyclopedia database.

The metadata file was generated with the documented command:

```
rse add https://github.com/helena-bioinformatics/noodle-mcp
```

Canonical sources:
- Product: https://noodle.helena.bio
- Source repository: https://github.com/helena-bioinformatics/noodle-mcp
- Software DOI: https://doi.org/10.5281/zenodo.22166486
- License: Apache-2.0

This follows the maintainer guidance in issue #489 to use `rse add` and contribute the generated database entry.