### PR TITLE
Add Folklore Clinical Variant Interpretation MCP

### DIFF
--- a/database/github/helena-bioinformatics/folklore-mcp/metadata.json
+++ b/database/github/helena-bioinformatics/folklore-mcp/metadata.json
@@ -1,0 +1,39 @@
+{
+    "parser": "github",
+    "uid": "github/helena-bioinformatics/folklore-mcp",
+    "url": "https://github.com/helena-bioinformatics/folklore-mcp",
+    "data": {
+        "name": "folklore-mcp",
+        "url": "https://github.com/helena-bioinformatics/folklore-mcp",
+        "full_name": "helena-bioinformatics/folklore-mcp",
+        "html_url": "https://github.com/helena-bioinformatics/folklore-mcp",
+        "private": false,
+        "description": "Folklore Clinical Variant Interpretation MCP — official public Helena Bioinformatics MCP for ACMG/AMP evidence and literature.",
+        "created_at": "2026-08-12T00:09:12Z",
+        "updated_at": "2026-08-31T11:29:43Z",
+        "clone_url": "https://github.com/helena-bioinformatics/folklore-mcp.git",
+        "homepage": "https://folklore.helena.bio/integrations",
+        "size": 303,
+        "stargazers_count": 0,
+        "watchers_count": 0,
+        "language": "Python",
+        "open_issues_count": 1,
+        "license": {
+            "key": "apache-2.0",
+            "name": "Apache License 2.0",
+            "spdx_id": "Apache-2.0",
+            "url": "https://api.github.com/licenses/apache-2.0",
+            "node_id": "MDc6TGljZW5zZTI="
+        },
+        "subscribers_count": 0,
+        "owner": {
+            "html_url": "https://github.com/helena-bioinformatics",
+            "avatar_url": "https://avatars.githubusercontent.com/u/243391023?v=4",
+            "login": "helena-bioinformatics",
+            "type": "Organization"
+        },
+        "topics": [],
+        "timestamp": "2026-08-31 14:35:00.000000",
+        "avatar": "https://avatars.githubusercontent.com/u/243391023?v=4"
+    }
+}


### PR DESCRIPTION
Adds Folklore Clinical Variant Interpretation MCP to the Research Software Encyclopedia metadata database.

Folklore is Helena Bioinformatics' Apache-2.0 public, read-only MCP adapter for source-linked GRCh38 germline variant interpretation, ACMG/AMP decision support, and biomedical literature discovery.

Canonical links:
- Source: https://github.com/helena-bioinformatics/folklore-mcp
- Product: https://folklore.helena.bio
- MCP endpoint: https://api.helena.bio/folklore/v1/mcp
- Official Registry: io.github.helena-bioinformatics/folklore